### PR TITLE
Update BLE wake handling and bump version to 1.0.5

### DIFF
--- a/custom_components/bloomin8_bt_wake/button.py
+++ b/custom_components/bloomin8_bt_wake/button.py
@@ -12,7 +12,8 @@ from .const import (
     DOMAIN,
     BLE_SERVICE_UUID,
     BLE_CHAR_UUID,
-    BLE_WAKE_PAYLOAD,
+    BLE_WAKE_PAYLOAD1,
+    BLE_WAKE_PAYLOAD2,
     CONF_MAC_ADDRESS,
 )
 
@@ -58,9 +59,11 @@ class Bloomin8WakeButton(ButtonEntity):
                      _LOGGER.error("Failed to connect to %s", self._mac)
                      return
 
-                # Write the confirmed magic byte
-                await client.write_gatt_char(BLE_CHAR_UUID, BLE_WAKE_PAYLOAD, response=True)
-                _LOGGER.info("Wake signal sent successfully!")
+                # Write the confirmed magic bytes
+                await client.write_gatt_char(BLE_CHAR_UUID, BLE_WAKE_PAYLOAD1, response=True)
+                _LOGGER.info("Wake signal 1 sent successfully!")
+                await client.write_gatt_char(BLE_CHAR_UUID, BLE_WAKE_PAYLOAD2, response=True)
+                _LOGGER.info("Wake signal 2 sent successfully!")
                 
         except Exception as e:
             _LOGGER.error("Failed to send wake signal: %s", e)

--- a/custom_components/bloomin8_bt_wake/const.py
+++ b/custom_components/bloomin8_bt_wake/const.py
@@ -7,6 +7,7 @@ CONF_MAC_ADDRESS = "mac_address"
 # Confirmed BLE Details from Reverse Engineering
 BLE_SERVICE_UUID = "0000f000-0000-1000-8000-00805f9b34fb"
 BLE_CHAR_UUID = "0000f001-0000-1000-8000-00805f9b34fb"
-BLE_WAKE_PAYLOAD = b"\x01"
+BLE_WAKE_PAYLOAD1 = b"\x01"
+BLE_WAKE_PAYLOAD2 = b"\x00"
 
 DEFAULT_NAME = "Bloomin8 Wake Button"

--- a/custom_components/bloomin8_bt_wake/manifest.json
+++ b/custom_components/bloomin8_bt_wake/manifest.json
@@ -8,5 +8,5 @@
     ],
     "documentation": "https://github.com/ARPOBOT-BLOOMIN8/bloomin8_bt_wake",
     "iot_class": "local_polling",
-    "version": "1.0.4"
+    "version": "1.0.5"
 }


### PR DESCRIPTION
Fixes #1 which was caused by only one of the two required packets being sent to wake the device.